### PR TITLE
Add watchOptions to webpack-dev-middleware

### DIFF
--- a/packages/vue-starter-service/src/webpack/dev/server.ts
+++ b/packages/vue-starter-service/src/webpack/dev/server.ts
@@ -42,6 +42,10 @@ export default (app: Express.Application, callback: any): void => {
       colors: true,
       chunks: false,
     },
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: 1000
+    },
   });
 
   app.use(devMiddleware as any);


### PR DESCRIPTION
Adding watchOptions to webpack-dev-middleware enables a vue-starter project built in Vagrant to recompile changes when a file is changed and saved.